### PR TITLE
Use correct data type when setting number of bounces

### DIFF
--- a/SKBounceAnimation/SKBounceAnimation.m
+++ b/SKBounceAnimation/SKBounceAnimation.m
@@ -113,7 +113,7 @@ SKBounceAnimationStiffness SKBounceAnimationStiffnessHeavy  = .001f;
 }
 
 - (void) setNumberOfBounces:(NSUInteger)newNumberOfBounces {
-	[super setValue:[NSNumber numberWithUnsignedInt:newNumberOfBounces] forKey:@"numberOfBouncesKey"];
+	[super setValue:[NSNumber numberWithUnsignedInteger:newNumberOfBounces] forKey:@"numberOfBouncesKey"];
 	[self createValueArray];
 }
 


### PR DESCRIPTION
In our project we have directly imported the SKBounceAnimation.{h,m} files into our project. We recently turned on additional compiler warnings in our project and discovered a implicit conversion warning in SKBounceAnimation.m. This PR fixes the one case where this warning happens.

It appears this warning only happens when compiling using the Standard Architectures setting in Xcode 5.1 with a 64-bit device connected (like an iPad Air). On 64-bit `unsigned int` is different from `NSUInteger`.
